### PR TITLE
Remove unrequired reference to ApplicationViewController.h

### DIFF
--- a/src/ios/app/AppDelegate+IndexAppContent.m
+++ b/src/ios/app/AppDelegate+IndexAppContent.m
@@ -7,7 +7,6 @@
 
 #import "AppDelegate+IndexAppContent.h"
 #import "IndexAppContent.h"
-#import "MainViewController.h"
 
 #define kCALL_DELAY_MILLISECONDS 25
 


### PR DESCRIPTION
This reference is not required and will not work when the default view controller of a cordova project has a different name
