### PR TITLE
Clear timestamp after items were deleted

### DIFF
--- a/src/ios/app/IndexAppContent.m
+++ b/src/ios/app/IndexAppContent.m
@@ -118,6 +118,7 @@ NSString *kIndexAppContentExecutionDelayKey = @"kIndexAppContentExecutionDelayKe
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR] callbackId:command.callbackId];
         } else {
             NSLog(@"Index removed for domains %@", domains);
+            [self _clearTimestamp];
             [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
         }
     }];
@@ -184,6 +185,11 @@ NSString *kIndexAppContentExecutionDelayKey = @"kIndexAppContentExecutionDelayKe
 - (NSDate *)_getTimestamp
 {
     return [[NSUserDefaults standardUserDefaults] objectForKey:kINDEX_TIMESTAMP_KEY];
+}
+
+- (void)_clearTimestamp
+{
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kINDEX_TIMESTAMP_KEY];
 }
 
 - (NSInteger)_getIndexingInterval


### PR DESCRIPTION
Fix for https://github.com/johanblomgren/cordova-plugin-indexappcontent/issues/8 in case consumer is using one domain only.

However, in case consumer uses different domains then timestamp handling needs to be redone to store timestamp per domain.
