### PR TITLE
Add handler for availability check of ionic-native

### DIFF
--- a/www/IndexAppContent.js
+++ b/www/IndexAppContent.js
@@ -58,6 +58,10 @@ IndexAppContent.prototype.setIndexingInterval = function (iMinutes, onSuccess, o
 	exec(onSuccess, onError, "IndexAppContent", "setIndexingInterval", [iMinutes]);
 };
 
+IndexAppContent.prototype.onItemPressed = function(payload) {
+	console.error("No handler assinged");
+};
+
 if (!window.plugins) {
 	window.plugins = {};
 }

--- a/www/IndexAppContent.js
+++ b/www/IndexAppContent.js
@@ -58,9 +58,7 @@ IndexAppContent.prototype.setIndexingInterval = function (iMinutes, onSuccess, o
 	exec(onSuccess, onError, "IndexAppContent", "setIndexingInterval", [iMinutes]);
 };
 
-IndexAppContent.prototype.onItemPressed = function(payload) {
-	console.error("No handler assinged");
-};
+IndexAppContent.prototype.onItemPressed = {dummy: "No handler assigned"};
 
 if (!window.plugins) {
 	window.plugins = {};


### PR DESCRIPTION
Since version 5 of [ionic-native](https://github.com/ionic-team/ionic-native) the `onItemPressed` handler did not work anymore. I found out that ionic-native now checks if the function to be overwritten is existing. That's why this PR adds a dummy.